### PR TITLE
improvement: optimize Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ COPY /gradle/ /app/gradle/
 COPY gradlew /app/
 COPY build.gradle.kts /app/
 COPY settings.gradle.kts /app/
-COPY gradle.properties /app/
 COPY /src/ /app/src/
 WORKDIR /app/
-RUN ./gradlew shadowJar
+RUN ./gradlew shadowJar --no-daemon
 
-FROM openjdk:11
+FROM openjdk:11-jre-slim
 COPY --from=builder /app/build/libs/firebridge-1.0-SNAPSHOT-all.jar /Firebridge.jar
 ENTRYPOINT ["java", "-jar", "/Firebridge.jar"]


### PR DESCRIPTION
Build no longer starts the Gradle daemon and the final image uses a slimmer version of JDK 11.