### PR TITLE
improvement: move startup validation into `Configuration.kt` and enale DI for `Configuration`

### DIFF
--- a/src/main/kotlin/com/github/frozensync/Configuration.kt
+++ b/src/main/kotlin/com/github/frozensync/Configuration.kt
@@ -1,0 +1,27 @@
+package com.github.frozensync
+
+import org.koin.core.Koin
+import java.util.*
+
+typealias DeviceId = UUID
+
+private const val DEVICE_ID_KEY = "DEVICE_ID"
+private const val GOOGLE_APPLICATION_CREDENTIALS_KEY = "GOOGLE_APPLICATION_CREDENTIALS"
+
+fun Koin.validateConfiguration(): String {
+    val errorMessage = StringBuilder()
+
+    getProperty<String>(DEVICE_ID_KEY)
+        ?.let { this.setProperty("DEVICE_ID", DeviceId.fromString(it)) }
+        ?: errorMessage.appendln("Missing environment variable: DEVICE_ID")
+
+    getProperty<String>(GOOGLE_APPLICATION_CREDENTIALS_KEY)
+        ?: errorMessage.appendln("Missing environment variable: GOOGLE_APPLICATION_CREDENTIALS")
+
+    return errorMessage.toString()
+}
+
+class Configuration(koin: Koin) {
+    val deviceId = koin.getProperty<DeviceId>(DEVICE_ID_KEY)!!
+    val googleCredentialsPath = koin.getProperty<String>(GOOGLE_APPLICATION_CREDENTIALS_KEY)!!
+}

--- a/src/main/kotlin/com/github/frozensync/Module.kt
+++ b/src/main/kotlin/com/github/frozensync/Module.kt
@@ -1,0 +1,7 @@
+package com.github.frozensync
+
+import org.koin.dsl.module
+
+val mainModule = module {
+    single { Configuration(getKoin()) }
+}

--- a/src/main/kotlin/com/github/frozensync/Properties.kt
+++ b/src/main/kotlin/com/github/frozensync/Properties.kt
@@ -1,4 +1,0 @@
-package com.github.frozensync
-
-const val RASPBERRY_PI_ID = "RASPBERRY_PI_ID"
-const val GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS"

--- a/src/main/kotlin/com/github/frozensync/logging/googlecloud/LoggingEnhancerImpl.kt
+++ b/src/main/kotlin/com/github/frozensync/logging/googlecloud/LoggingEnhancerImpl.kt
@@ -1,13 +1,17 @@
 package com.github.frozensync.logging.googlecloud
 
-import com.github.frozensync.RASPBERRY_PI_ID
+import com.github.frozensync.Configuration
 import com.google.cloud.logging.LogEntry
 import com.google.cloud.logging.LoggingEnhancer
 import org.koin.core.KoinComponent
+import org.koin.core.get
 
 class LoggingEnhancerImpl : LoggingEnhancer, KoinComponent {
+
+    private val configuration: Configuration = get()
+
     override fun enhanceLogEntry(builder: LogEntry.Builder) {
-        val id = getKoin().getProperty<String>(RASPBERRY_PI_ID)!!
+        val id = configuration.deviceId.toString()
 
         builder.addLabel("component", "raspberry-pi")
         builder.addLabel("component-id", id)

--- a/src/main/kotlin/com/github/frozensync/persistence/firestore/FirestoreFactory.kt
+++ b/src/main/kotlin/com/github/frozensync/persistence/firestore/FirestoreFactory.kt
@@ -1,34 +1,20 @@
 package com.github.frozensync.persistence.firestore
 
-import com.github.frozensync.GOOGLE_APPLICATION_CREDENTIALS
+import com.github.frozensync.Configuration
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.firestore.Firestore
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.google.firebase.cloud.FirestoreClient
-import org.koin.core.KoinComponent
 import java.io.File
 
 /**
  * Factory which constructs [Firestore] instances.
  */
-class FirestoreFactory : KoinComponent {
+class FirestoreFactory(private val configuration: Configuration) {
 
-    private var initialized = false
-
-    /**
-     * Returns a [Firestore] instance associated with the default Firebase app. Always returns the same instance.
-     */
-    fun get(): Firestore {
-        if (!initialized) {
-            initializeDefaultFirebaseApp()
-            initialized = true
-        }
-        return FirestoreClient.getFirestore()
-    }
-
-    private fun initializeDefaultFirebaseApp() {
-        val credentialsPath = getKoin().getProperty<String>(GOOGLE_APPLICATION_CREDENTIALS)!!
+    private val defaultFirebaseApp by lazy {
+        val credentialsPath = configuration.googleCredentialsPath
         val credentials = GoogleCredentials.fromStream(File(credentialsPath).inputStream())
         val options = FirebaseOptions.Builder()
             .setCredentials(credentials)
@@ -36,4 +22,9 @@ class FirestoreFactory : KoinComponent {
             .build()
         FirebaseApp.initializeApp(options)
     }
+
+    /**
+     * Returns a [Firestore] instance associated with the default Firebase app. Always returns the same instance.
+     */
+    fun get(): Firestore = FirestoreClient.getFirestore(defaultFirebaseApp)
 }

--- a/src/main/kotlin/com/github/frozensync/persistence/firestore/Module.kt
+++ b/src/main/kotlin/com/github/frozensync/persistence/firestore/Module.kt
@@ -3,5 +3,5 @@ package com.github.frozensync.persistence.firestore
 import org.koin.dsl.module
 
 val firestoreModule = module {
-    single { FirestoreFactory().get() }
+    single { FirestoreFactory(get()).get() }
 }

--- a/src/main/kotlin/com/github/frozensync/raspberrypi/Module.kt
+++ b/src/main/kotlin/com/github/frozensync/raspberrypi/Module.kt
@@ -3,5 +3,5 @@ package com.github.frozensync.raspberrypi
 import org.koin.dsl.module
 
 val raspberryPiModule = module {
-    single<RaspberryPiService> { RaspberryPiServiceImpl(get()) }
+    single<RaspberryPiService> { RaspberryPiServiceImpl(get(), get()) }
 }

--- a/src/main/kotlin/com/github/frozensync/raspberrypi/RaspberryPi.kt
+++ b/src/main/kotlin/com/github/frozensync/raspberrypi/RaspberryPi.kt
@@ -1,5 +1,5 @@
 package com.github.frozensync.raspberrypi
 
-import java.util.*
+import com.github.frozensync.DeviceId
 
-data class RaspberryPi(val id: UUID, val owned: Boolean = false)
+data class RaspberryPi(val id: DeviceId, val owned: Boolean = false)

--- a/src/main/kotlin/com/github/frozensync/raspberrypi/RaspberryPiService.kt
+++ b/src/main/kotlin/com/github/frozensync/raspberrypi/RaspberryPiService.kt
@@ -1,14 +1,12 @@
 package com.github.frozensync.raspberrypi
 
-import java.util.*
-
 /**
- * Interface for business logic operations on [RaspberryPi]s.
+ * Service containing business logic operations on [RaspberryPi]s.
  */
 interface RaspberryPiService {
 
     /**
-     * Registers a new raspberry pi with given [id]. If it's already registered, fail silently.
+     * Preregisters this device if not already preregistered.
      */
-    suspend fun register(id: UUID)
+    suspend fun register()
 }

--- a/src/main/kotlin/com/github/frozensync/raspberrypi/RaspberryPiServiceImpl.kt
+++ b/src/main/kotlin/com/github/frozensync/raspberrypi/RaspberryPiServiceImpl.kt
@@ -1,28 +1,29 @@
 package com.github.frozensync.raspberrypi
 
+import com.github.frozensync.Configuration
 import com.github.frozensync.persistence.firestore.retry
 import com.google.api.gax.rpc.AlreadyExistsException
 import com.google.cloud.firestore.Firestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
-import java.util.*
 import java.util.concurrent.ExecutionException
 
 private const val RASPBERRY_PI_COLLECTION = "raspberryPis"
 
-class RaspberryPiServiceImpl(private val db: Firestore) : RaspberryPiService {
+class RaspberryPiServiceImpl(private val configuration: Configuration, private val db: Firestore) : RaspberryPiService {
 
     private val logger = KotlinLogging.logger { }
 
-    override suspend fun register(id: UUID) {
-        logger.entry(id)
-        logger.info { "Registering device..." }
+    override suspend fun register() {
+        logger.entry()
 
-        val raspberryPi = RaspberryPi(id)
+        val deviceId = configuration.deviceId
+        val raspberryPi = RaspberryPi(deviceId)
         val raspberryPiRef = db.collection(RASPBERRY_PI_COLLECTION).document(raspberryPi.id.toString())
         val data = mapOf("owned" to raspberryPi.owned)
 
+        logger.info { "Registering device..." }
         retry {
             withContext(Dispatchers.IO) {
                 try {

--- a/src/main/kotlin/com/github/frozensync/tournament/TournamentModule.kt
+++ b/src/main/kotlin/com/github/frozensync/tournament/TournamentModule.kt
@@ -1,8 +1,7 @@
 package com.github.frozensync.tournament
 
-import com.github.frozensync.RASPBERRY_PI_ID
 import org.koin.dsl.module
 
 val tournamentModule = module {
-    single<TournamentService> { TournamentServiceImpl(get(), getProperty(RASPBERRY_PI_ID)) }
+    single<TournamentService> { TournamentServiceImpl(get(), get()) }
 }

--- a/src/main/kotlin/com/github/frozensync/tournament/TournamentServiceImpl.kt
+++ b/src/main/kotlin/com/github/frozensync/tournament/TournamentServiceImpl.kt
@@ -1,24 +1,26 @@
 package com.github.frozensync.tournament
 
+import com.github.frozensync.Configuration
 import com.google.cloud.firestore.Firestore
 import mu.KotlinLogging
 
-class TournamentServiceImpl(private val db: Firestore, private val raspberryPiId: String) : TournamentService {
+class TournamentServiceImpl(private val configuration: Configuration, private val db: Firestore) : TournamentService {
 
     private val logger = KotlinLogging.logger { }
 
     override fun save(score: Score) {
         logger.entry(score)
 
+        val deviceId = configuration.deviceId.toString()
         val scoreAsMap = mapOf("result" to score.result)
 
         db.runTransaction { transaction ->
-            val assignmentRef = db.collection("tournamentAssignments").document(raspberryPiId)
+            val assignmentRef = db.collection("tournamentAssignments").document(deviceId)
             val assignment = transaction.get(assignmentRef).get()
             val tournamentId = assignment.getString("tournamentId") ?: return@runTransaction
 
             val serverRef = db.collection("tournaments").document(tournamentId)
-                .collection("servers").document(raspberryPiId)
+                .collection("servers").document(deviceId)
             val server = transaction.get(serverRef).get()
 
             if (server.exists()) {


### PR DESCRIPTION
This change allows the program to fail early in one place. If startup succeeds, configuration properties are injected throughout the program in a type-safe way.

Closes #19 