### PR TITLE
feat: mock control program communication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,3 +105,20 @@ tasks {
         }
     }
 }
+
+tasks.register<JavaExec>("ControlProgramMockServer") {
+    dependsOn("classes")
+    classpath = sourceSets["main"].runtimeClasspath
+    main = "com.github.frozensync.tournament.ControlProgramMockServerKt"
+}
+
+val controlProgramMockServerStartScripts = tasks.register<CreateStartScripts>("controlProgramMockServerStartScripts") {
+    mainClassName = "com.github.frozensync.tournament.ControlProgramMockServerKt"
+    applicationName = "control-program-mock-server"
+    outputDir = tasks.named<CreateStartScripts>("startScripts").get().outputDir
+    classpath = tasks.named<CreateStartScripts>("startScripts").get().classpath
+}
+
+tasks.named("startScripts") {
+    dependsOn(controlProgramMockServerStartScripts)
+}

--- a/src/main/kotlin/com/github/frozensync/tournament/ControlProgramClient.kt
+++ b/src/main/kotlin/com/github/frozensync/tournament/ControlProgramClient.kt
@@ -1,0 +1,21 @@
+package com.github.frozensync.tournament
+
+import com.github.frozensync.tournament.ControlProgramGrpcKt.ControlProgramCoroutineStub
+import io.grpc.ManagedChannel
+import kotlinx.coroutines.coroutineScope
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+class ControlProgramClient constructor(private val channel: ManagedChannel) : Closeable {
+
+    private val stub: ControlProgramCoroutineStub = ControlProgramCoroutineStub(channel)
+
+    suspend fun sendScore(score: Score) = coroutineScope {
+        val request = ScoreRequest.newBuilder().setScore(score.result).build()
+        stub.sendScore(request)
+    }
+
+    override fun close() {
+        channel.shutdown().awaitTermination(5, TimeUnit.SECONDS)
+    }
+}

--- a/src/main/kotlin/com/github/frozensync/tournament/ControlProgramMockServer.kt
+++ b/src/main/kotlin/com/github/frozensync/tournament/ControlProgramMockServer.kt
@@ -1,0 +1,48 @@
+package com.github.frozensync.tournament
+
+import io.grpc.Server
+import io.grpc.ServerBuilder
+
+/**
+ * A mock of a BridgeMate server connected to the control program. Its purpose is to verify the RPC communication.
+ */
+private class ControlProgramMockServer constructor(private val port: Int) {
+
+    private val server: Server = ServerBuilder
+        .forPort(port)
+        .addService(ControlProgramService())
+        .build()
+
+    fun start() {
+        server.start()
+        println("Server started, listening on $port")
+
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                this@ControlProgramMockServer.stop()
+                println("Server shut down")
+            }
+        )
+    }
+
+    private fun stop() {
+        server.shutdown()
+    }
+
+    fun blockUntilShutdown() {
+        server.awaitTermination()
+    }
+
+    private class ControlProgramService : ControlProgramGrpcKt.ControlProgramCoroutineImplBase() {
+        override suspend fun sendScore(request: ScoreRequest): Empty {
+            println(request)
+            return Empty.getDefaultInstance()
+        }
+    }
+}
+
+fun main() {
+    val server = ControlProgramMockServer(port = 8981)
+    server.start()
+    server.blockUntilShutdown()
+}

--- a/src/main/kotlin/com/github/frozensync/tournament/Score.kt
+++ b/src/main/kotlin/com/github/frozensync/tournament/Score.kt
@@ -2,5 +2,5 @@ package com.github.frozensync.tournament
 
 // other fields left out for now for easier testing
 data class Score(
-    val result: Int
+    val result: Long
 )

--- a/src/main/kotlin/com/github/frozensync/tournament/Tournament.kt
+++ b/src/main/kotlin/com/github/frozensync/tournament/Tournament.kt
@@ -1,6 +1,5 @@
 package com.github.frozensync.tournament
 
-import com.github.frozensync.database.FirestoreDocument
 import java.util.*
 
 data class Tournament(val id: String, val map: Map<String, Any?>) {
@@ -8,9 +7,11 @@ data class Tournament(val id: String, val map: Map<String, Any?>) {
     val name: String by map
     val date: Date by map
     val live: Boolean by map
-    val assignedRaspberryPis: List<Assignment> by map
+    val assignedRaspberryPis: List<Map<String, Any?>> by map
     val deviceIds: List<String> by map
 }
 
-@FirestoreDocument
-data class Assignment(val id: String, val role: String)
+data class Assignment(val map: Map<String, Any?>) {
+    val id: String by map
+    val role: String by map
+}

--- a/src/main/kotlin/com/github/frozensync/tournament/TournamentService.kt
+++ b/src/main/kotlin/com/github/frozensync/tournament/TournamentService.kt
@@ -2,13 +2,19 @@ package com.github.frozensync.tournament
 
 import com.github.frozensync.DeviceId
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.Flow
 
 interface TournamentService {
 
     /**
-     * Returns a live tournament by director [directorId] which device [deviceId] is assigned to.
+     * Returns a live tournament by director [directorId] to which device [deviceId] is assigned to.
      */
     suspend fun getLiveTournamentAsync(directorId: String, deviceId: DeviceId): Deferred<Tournament>
+
+    /**
+     * Returns a flow of incoming scores.
+     */
+    suspend fun streamScores(directorId: String, tournamentId: String): Flow<Score>
 
     /**
      * Adds a [score] for tournament [tournamentId] by director [directorId].

--- a/src/main/proto/tournament.proto
+++ b/src/main/proto/tournament.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 option java_multiple_files = true;
 option java_package = "com.github.frozensync.tournament";
-option java_outer_classname = "TournamentScorerProto";
+option java_outer_classname = "TournamentProto";
 
 package tournament;
 
@@ -10,8 +10,12 @@ service Scorer {
   rpc SendScore (ScoreRequest) returns (Empty) {}
 }
 
+service ControlProgram {
+  rpc SendScore (ScoreRequest) returns (Empty) {}
+}
+
 message ScoreRequest {
-  int32 score = 1;
+  int64 score = 1;
 }
 
 message Empty {}


### PR DESCRIPTION
`Score#result` is changed from `Int` to `Long` because Firestore only stores 64-bit numbers.

Closes #44 